### PR TITLE
Fixed definition of OEM_EXPORT on Windows

### DIFF
--- a/src/include/oem/oem_export.h
+++ b/src/include/oem/oem_export.h
@@ -3,40 +3,51 @@
 #define OEM_EXPORT_H
 
 #ifdef OEM_STATIC_DEFINE
-#  define OEM_EXPORT
-#  define OEM_NO_EXPORT
+  #define OEM_EXPORT
+  #define OEM_NO_EXPORT
 #else
-#  ifndef OEM_EXPORT
-#    ifdef oem_EXPORTS
+  #ifndef OEM_EXPORT
+    #ifdef WIN32
+      #ifdef OEM_EXPORTS
         /* We are building this library */
-#      define OEM_EXPORT __attribute__((visibility("default")))
-#    else
+        #define OEM_EXPORT __declspec(dllexport)
+      #else
         /* We are using this library */
-#      define OEM_EXPORT __attribute__((visibility("default")))
-#    endif
-#  endif
+        #define OEM_EXPORT __declspec(dllimport)
+      #endif
+    #else
+      #ifdef OEM_EXPORTS
+        /* We are building this library */
+        #define OEM_EXPORT __attribute__((visibility("default")))
+      #else
+        /* We are using this library */
+        #define OEM_EXPORT __attribute__((visibility("default")))
+      #endif
+    #endif
+  #endif
 
-#  ifndef OEM_NO_EXPORT
-#    define OEM_NO_EXPORT __attribute__((visibility("hidden")))
-#  endif
-#endif
+  #ifndef OEM_NO_EXPORT
+    #define OEM_NO_EXPORT __attribute__((visibility("hidden")))
+  #endif
+
+#endif /* OEM_STATIC_DEFINE */
 
 #ifndef OEM_DEPRECATED
-#  define OEM_DEPRECATED 
+  #define OEM_DEPRECATED 
 #endif
 
 #ifndef OEM_DEPRECATED_EXPORT
-#  define OEM_DEPRECATED_EXPORT OEM_EXPORT OEM_DEPRECATED
+  #define OEM_DEPRECATED_EXPORT OEM_EXPORT OEM_DEPRECATED
 #endif
 
 #ifndef OEM_DEPRECATED_NO_EXPORT
-#  define OEM_DEPRECATED_NO_EXPORT OEM_NO_EXPORT OEM_DEPRECATED
+  #define OEM_DEPRECATED_NO_EXPORT OEM_NO_EXPORT OEM_DEPRECATED
 #endif
 
 #if 0 /* DEFINE_NO_DEPRECATED */
-#  ifndef OEM_NO_DEPRECATED
-#    define OEM_NO_DEPRECATED
-#  endif
+  #ifndef OEM_NO_DEPRECATED
+    #define OEM_NO_DEPRECATED
+  #endif
 #endif
 
 #endif /* OEM_EXPORT_H */


### PR DESCRIPTION
On Windows OEM_EXPORT should be set to __declspec(dllexport / dllimport) instead of __attribute__((visibility("default"))). This causes a build error.

These proposed changes are confirmed to fix this on MSVC compilers, and should also work for MinGW compilers. 

I have also made a minor stylistic change to the indentation to try to improve readability. I can change it back to the way it was if this is preferred.