### PR TITLE
Update documentation for v9.1.0, improve README organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,25 +41,65 @@ Bluetooth Low Energy (BLE) is used to make the initial connection with the Clari
 - Power Service (PWS)
 - Wi-Fi Information Service (WIS)
 
+## Power Service
+
 The __PWS__ (UUID 0x8C853B6A-2297-44C1-8277-73627C8D2ABC) is a custom service built by clarius to read and manage the power status of the scanner.
 
+### Power Published Characteristic:
 Once ready, the device powered status will be published through the __Power Published__ characteristic (UUID 0x8C853B6A-2297-44C1-8277-73627C8D2ABD), and can be read at any point after a BLE connection, as well as subscribed to, and thus a notification will take place when the information has changed. The read and notifications should always be 1 byte, with 0 denoting an off state, and 1 denoting an on state.
 
 To subscribe to the Power Published characteristic, one can write 0100 to the characteristic's Client Characteristic Configuration Descriptor (CCCD), allowing the scanner to send out notifications to the connected program.
 
+### Power Request Characteristic:
 To power on or off the device, the __Power Request__ characteristic (UUID 0x8C853B6A-2297-44C1-8277-73627C8D2ABE) can be written to. Writing 0x00 to the characteristic will power the device off, and writing 0x01 will power the device on.
 
+## Wi-Fi Information Service
 The __WIS__ (UUID 0xF9EB3FAE-947A-4E5B-AB7C-C799E91ED780) is a custom service built by Clarius to read and manage the Wi-Fi network once the scanner is powered up and ready. A scanner is typically in a ready state when the LED has stopped flashing and is solid blue.
 
+### Wi-Fi Published Characteristic:
 Once ready, the current Wi-Fi network information will be published through the __Wi-Fi Published__ characteristic (UUID 0xF9EB3FAE-947A-4E5B-AB7C-C799E91ED781), and can be read at any point after a BLE connection, as well as subscribed to, and thus a notification will take place when the information has changed. If the service reads back "N/A" it typically means the scanners has not finished booting to a ready state.
 
 To subscribe to the Wi-Fi Published characteristic, one can write 0100 to the characteristic's Client Characteristic Configuration Descriptor (CCCD), allowing the scanner to send out notifications to the connected program.
 
-The format of the read back text from the characteristic is as follows: _SSID,PASSWORD,V4_IP_ADDRESS,V6_IP_ADDRESS,TCP_CONNECTION_PORT_. Note that the password will only be sent if the network used is the scanner's own Access Point (AP). If connected to a router, the password will not be sent as it is assumed that the credentials are managed elsewhere.
+The format of the read back text from the characteristic is as follows:
 
+If the scanner is still booting up and the Wi-Fi network is not yet ready:
+```
+state: disabled
+```
+
+If the Wi-Fi network is in AP mode and ready for connection:
+```
+state: connected
+ap: true
+ssid: DIRECT-<probe serial number>
+pw: <probe network password>
+ip4: 192.168.1.1
+ctl: 12345
+cast: 67890
+avail: available
+channel: 123
+mac: <mac address>
+```
+Note that the password will only be sent if the network used is the scanner's own Access Point (AP). If connected to a router, the password will not be sent as it is assumed that the credentials are managed elsewhere.
+
+### Wi-Fi Request Characteristic:
 To change network configurations, the __Wi-Fi Request__ characteristic (UUID 0xF9EB3FAE-947A-4E5B-AB7C-C799E91ED782) can be written to. Note that the probe must be in a ready state before the request will have any effect.
 
-To request to put the scanner on a router (or any other external network), write to the characteristic in the following format: _SSID,PASSWORD_. To put the scanner on it's internal access point, simply send: _p2pRequest,auto_. Once the scanner has joined or launched the Wi-Fi network, the published characteristic will be subsequently written. In the event of an error, "N/A" will be published.
+To put the scanner on it's internal access point, simply send:
+```
+ap: true
+channel: <'auto' or channel number>
+```
+
+To request to put the scanner on a router (or any other external network), write to the characteristic in the following format:
+```
+ap: false
+ssid: <network ssid>
+password: <network password>
+```
+
+Once the scanner has joined or launched the Wi-Fi network, the published characteristic will be subsequently written.
 
 # Examples
 


### PR DESCRIPTION
The sent & returned Wi-fi control strings seem to have changed in the newer OEM API versions compared to what is documented in README.md.

This commit should make the string descriptions current with OEM API v9.1.0.

This commit also attempts to improve the readability of README.md by introducing headings for each BLE service / characteristic.